### PR TITLE
Add support for other languages in app strings

### DIFF
--- a/PHPUnit/Extensions/AppiumTestCase/Session.php
+++ b/PHPUnit/Extensions/AppiumTestCase/Session.php
@@ -40,7 +40,6 @@ class PHPUnit_Extensions_AppiumTestCase_Session
      */
     public function elementFromResponseValue($value)
     {
-        echo "here";
         return PHPUnit_Extensions_Selenium2TestCase_Element::fromResponseValue($value, $this->getSessionUrl()->descend('element'), $this->driver);
     }
 
@@ -50,10 +49,14 @@ class PHPUnit_Extensions_AppiumTestCase_Session
         $this->driver->curl('POST', $url);
     }
 
-    public function appStrings()
+    public function appStrings($language=NULL)
     {
         $url = $this->getSessionUrl()->addCommand('appium/app/strings');
-        return $this->driver->curl('GET', $url)->getValue();
+        $data = array();
+        if (!is_null($language)) {
+            $data['language'] = $language;
+        }
+        return $this->driver->curl('POST', $url, $data)->getValue();
     }
 
     public function keyEvent($keycode, $metastate=null)

--- a/test/functional/android/appium_tests.php
+++ b/test/functional/android/appium_tests.php
@@ -26,6 +26,12 @@ class AppiumTests extends PHPUnit_Extensions_AppiumTestCase
         $this->assertEquals('You can\'t wipe my data, you are a monkey!', $strings['monkey_wipe_data']);
     }
 
+    public function testAppStringsNonDefault()
+    {
+        $strings = $this->appStrings("en");
+        $this->assertEquals('You can\'t wipe my data, you are a monkey!', $strings['monkey_wipe_data']);
+    }
+
     public function testKeyEvent()
     {
         $this->byAccessibilityId('App')->click();


### PR DESCRIPTION
Pass in language to `appStrings` to get strings in non-default languages. Address issue #5.
