### PR TITLE
Update caps to include platformName and deviceName

### DIFF
--- a/test/functional/android/accessor_tests.php
+++ b/test/functional/android/accessor_tests.php
@@ -46,7 +46,10 @@ class ContextTests extends PHPUnit_Extensions_AppiumTestCase
             'port' => 4723,
             'browserName' => '',
             'desiredCapabilities' => array(
-                'app' => APP_PATH
+                'app' => APP_PATH,
+                'platformName' => 'Android',
+                'platformVersion' => '4.4',
+                'deviceName' => 'Android Emulator'
             )
         )
     );

--- a/test/functional/android/appium_tests.php
+++ b/test/functional/android/appium_tests.php
@@ -186,9 +186,10 @@ class AppiumTests extends PHPUnit_Extensions_AppiumTestCase
             'port' => 4723,
             'browserName' => '',
             'desiredCapabilities' => array(
-                'deviceName' => 'Android Emulator',
+                'app' => APP_PATH,
                 'platformName' => 'Android',
-                'app' => APP_PATH
+                'platformVersion' => '4.4',
+                'deviceName' => 'Android Emulator'
             )
         )
     );

--- a/test/functional/android/context_tests.php
+++ b/test/functional/android/context_tests.php
@@ -64,7 +64,10 @@ class ContextTests extends PHPUnit_Extensions_AppiumTestCase
             'port' => 4723,
             'browserName' => '',
             'desiredCapabilities' => array(
-                'app' => APP_PATH
+                'app' => APP_PATH,
+                'platformName' => 'Android',
+                'platformVersion' => '4.4',
+                'deviceName' => 'Android Emulator'
             )
         )
     );

--- a/test/functional/android/multiaction_tests.html
+++ b/test/functional/android/multiaction_tests.html
@@ -31,7 +31,10 @@ class MultiActionTests extends PHPUnit_Extensions_AppiumTestCase
             'port' => 4723,
             'browserName' => '',
             'desiredCapabilities' => array(
-                'app' => APP_PATH
+                'app' => APP_PATH,
+                'platformName' => 'Android',
+                'platformVersion' => '4.4',
+                'deviceName' => 'Android Emulator'
             )
         )
     );

--- a/test/functional/android/touchaction_tests.php
+++ b/test/functional/android/touchaction_tests.php
@@ -31,7 +31,10 @@ class TouchActionTests extends PHPUnit_Extensions_AppiumTestCase
             'port' => 4723,
             'browserName' => '',
             'desiredCapabilities' => array(
-                'app' => APP_PATH
+                'app' => APP_PATH,
+                'platformName' => 'Android',
+                'platformVersion' => '4.4',
+                'deviceName' => 'Android Emulator'
             )
         )
     );

--- a/test/functional/ios/accessor_tests.php
+++ b/test/functional/ios/accessor_tests.php
@@ -22,7 +22,10 @@ class AccessorTests extends PHPUnit_Extensions_AppiumTestCase
             'port' => 4723,
             'browserName' => '',
             'desiredCapabilities' => array(
-                'app' => APP_PATH
+                'app' => APP_PATH,
+                'platformName' => 'iOS',
+                'platformVersion' => '7.1',
+                'deviceName' => 'iPhone Simulator'
             )
         )
     );

--- a/test/functional/ios/appium_tests.php
+++ b/test/functional/ios/appium_tests.php
@@ -98,9 +98,10 @@ class AppiumTests extends PHPUnit_Extensions_AppiumTestCase
             'port' => 4723,
             'browserName' => '',
             'desiredCapabilities' => array(
-                'deviceName' => 'iPhone Simulator',
+                'app' => APP_PATH,
                 'platformName' => 'iOS',
-                'app' => APP_PATH
+                'platformVersion' => '7.1',
+                'deviceName' => 'iPhone Simulator'
             )
         )
     );


### PR DESCRIPTION
Appium 1.2 requires the desired capabilities `platformName` and `deviceName`. Resolves #17
