### PR TITLE
Fixed getting one or more children of an element

### DIFF
--- a/PHPUnit/Extensions/AppiumTestCase/Element.php
+++ b/PHPUnit/Extensions/AppiumTestCase/Element.php
@@ -84,13 +84,12 @@ class PHPUnit_Extensions_AppiumTestCase_Element
 
     public function elements(PHPUnit_Extensions_Selenium2TestCase_ElementCriteria $criteria)
     {
-        $session = $this->prepareSession();
-        $values = $session->postCommand('elements', $criteria);
+        $values = $this->postCommand('elements', $criteria);
         $elements = array();
         foreach ($values as $value) {
             $elements[] =
                 PHPUnit_Extensions_AppiumTestCase_Element::fromResponseValue(
-                    $value, $session->getSessionUrl()->descend('element'), $session->driver);
+                    $value, $this->getSessionUrl()->descend('element'), $this->driver);
         }
         return $elements;
     }


### PR DESCRIPTION
The "elements" function used to call prepareSession(), which isn't defined for the element. Instead it should use $this just like the "element" method right above it.

As described in #26.
