### PR TITLE
Added secure server flag to fromHostAndPort call for https servers.

### DIFF
--- a/PHPUnit/Extensions/AppiumTestCase/SessionStrategy/Isolated.php
+++ b/PHPUnit/Extensions/AppiumTestCase/SessionStrategy/Isolated.php
@@ -21,7 +21,7 @@ class PHPUnit_Extensions_AppiumTestCase_SessionStrategy_Isolated
 {
     public function session(array $parameters)
     {
-        $seleniumServerUrl = PHPUnit_Extensions_Selenium2TestCase_URL::fromHostAndPort($parameters['host'], $parameters['port']);
+        $seleniumServerUrl = PHPUnit_Extensions_Selenium2TestCase_URL::fromHostAndPort($parameters['host'], $parameters['port'], $parameters['secure']);
         $driver = new PHPUnit_Extensions_AppiumTestCase_Driver($seleniumServerUrl, $parameters['seleniumServerRequestsTimeout']);
         $capabilities = array_merge($parameters['desiredCapabilities'],
                                     array(


### PR DESCRIPTION
The selenium server is resolve by concatenation in `PHPUnit_Extensions_Selenium2TestCase_URL:: fromHostAndPort` in [URL.php](https://github.com/giorgiosironi/phpunit-selenium/blob/master/PHPUnit/Extensions/Selenium2TestCase/URL.php). To add support for https server this [PR](https://github.com/giorgiosironi/phpunit-selenium/pull/426) has been made. To reflect these changes in the Appium client the call to the method `fromHostAndPort` needs to be made using  with the `secure` flag in its parameters.