### PR TITLE
third argument is no needed

### DIFF
--- a/PHPUnit/Extensions/AppiumTestCase/SessionStrategy/Isolated.php
+++ b/PHPUnit/Extensions/AppiumTestCase/SessionStrategy/Isolated.php
@@ -21,7 +21,7 @@ class PHPUnit_Extensions_AppiumTestCase_SessionStrategy_Isolated
 {
     public function session(array $parameters)
     {
-        $seleniumServerUrl = PHPUnit_Extensions_Selenium2TestCase_URL::fromHostAndPort($parameters['host'], $parameters['port'], $parameters['secure']);
+        $seleniumServerUrl = PHPUnit_Extensions_Selenium2TestCase_URL::fromHostAndPort($parameters['host'], $parameters['port']);
         $driver = new PHPUnit_Extensions_AppiumTestCase_Driver($seleniumServerUrl, $parameters['seleniumServerRequestsTimeout']);
         $capabilities = array_merge($parameters['desiredCapabilities'],
                                     array(


### PR DESCRIPTION
hi
I tried to make auto test.
But i got a error.

```
1) IosCreateWebSession::testShouldCreateAndDestroySafariSession
Undefined index: secure

/Users/xxxxx/ios_unittest_appium/vendor/appium/php-client/PHPUnit/Extensions/AppiumTestCase/SessionStrategy/Isolated.php:25
/Users/xxxxx/ios_unittest_appium/vendor/phpunit/phpunit-selenium/PHPUnit/Extensions/Selenium2TestCase.php:319
/Users/xxxxx/ios_unittest_appium/vendor/phpunit/phpunit-selenium/PHPUnit/Extensions/Selenium2TestCase.php:360
/Users/xxxxx/ios_unittest_appium/vendor/phpunit/phpunit-selenium/PHPUnit/Extensions/Selenium2TestCase.php:337
```

then i checked 'Isolated.php:25' 
```
$seleniumServerUrl = PHPUnit_Extensions_Selenium2TestCase_URL::fromHostAndPort($parameters['host'], $parameters['port'], $parameters['secure'])
```
and i checked this also

```
/**
     * @param string $host
     * @param int port
     * @return PHPUnit_Extensions_Selenium2TestCase_URL
     */
    public static function fromHostAndPort($host, $port)
    {
        return new self("http://{$host}:{$port}");
    }
```
so that i think third argument is no needed.

Could you accept my pull request?
