### PR TITLE
bump up phpunit/phpunit-selenium since current master only support secure parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   }],
   "require": {
     "php": ">=5.3.0",
-    "phpunit/phpunit-selenium": ">=1.3.3"
+    "phpunit/phpunit-selenium": ">4.1.0"
   },
   "support": {
     "email": "help@saucelabs.com",


### PR DESCRIPTION
do not merge this yet.

Currently, https://github.com/giorgiosironi/phpunit-selenium/releases/tag/4.1.0 is the latest phpunit/phpunit-selenium released version.

After the release, a secure parameter has been added. After https://github.com/appium/php-client/pull/46 , this client also can work with the secure parameter. But the change breaks under 4.1.0.

This PR is just remark for making sure current master need the latest phpunit/phpunit-selenium 